### PR TITLE
Authed endpoints

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -5,6 +5,16 @@ HOST: http://teachers.odl.mit.edu/
 
 CCXCon is a simple API serves as an interface between edX running instances and different MIT apps.
 
+## Authentication
+
+To authenticate with this API, you must have a known token. You can
+request these from the maintainers of this service. You pass that in
+the `Authentication` header using the token scheme. If you were given
+the key `asdf1234`, you would include a header as illustrated
+below. This is required for all requests.
+
+`Authorization: Token asdf1234`
+
 ## Group Courses
 
 ## Courses Collection [/api/v1/coursexs/]

--- a/apiary_hooks.py
+++ b/apiary_hooks.py
@@ -8,6 +8,7 @@ import dredd_hooks as hooks  # pylint: disable=import-error
 django.setup()
 
 # This import must come after django setup
+from django.conf import settings  # noqa
 from courses.models import Course, Module  # noqa
 
 
@@ -51,6 +52,13 @@ def make_module_price_nullable(transactions):
             t['expected']['bodySchema'] = json.dumps(schema)
         except KeyError:
             pass
+
+
+@hooks.before_all
+def logged_in(transactions):
+    access_token = settings.CCXCON_ALLOWED_CLIENT_KEYS.copy().pop()
+    for t in transactions:
+        t['request']['headers']['Authorization'] = "Token {}".format(access_token)
 
 
 @hooks.before("Courses > Courses Collection > List All Courses")

--- a/ccxcon/settings.py
+++ b/ccxcon/settings.py
@@ -109,7 +109,7 @@ STATIC_URL = '/static/'
 
 CCXCON_ALLOWED_CLIENT_KEYS = set(
     os.getenv('ALLOWED_CLIENT_AUTH_KEYS',
-              "4d933e0d-aac9-4587-a73b-89799eb68cbf" if DEBUG else None).split(),
+              "4d933e0d-aac9-4587-a73b-89799eb68cbf" if DEBUG else tuple()).split(),
     )
 
 REST_FRAMEWORK = {

--- a/ccxcon/settings.py
+++ b/ccxcon/settings.py
@@ -106,3 +106,17 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/1.8/howto/static-files/
 
 STATIC_URL = '/static/'
+
+CCXCON_ALLOWED_CLIENT_KEYS = set(
+    os.getenv('ALLOWED_CLIENT_AUTH_KEYS',
+              "4d933e0d-aac9-4587-a73b-89799eb68cbf" if DEBUG else None).split(),
+    )
+
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'courses.authentication.KeyAuthentication',
+    ),
+    'DEFAULT_PERMISSION_CLASSES': (
+        'rest_framework.permissions.IsAuthenticated',
+    )
+}

--- a/courses/authentication.py
+++ b/courses/authentication.py
@@ -7,7 +7,9 @@ from rest_framework import authentication, exceptions
 
 class ValidUser(object):
     """
-    Represents a valid user for login purposes.
+    Represents a valid user for login purposes. This is required to get
+    django-rest-framework to consider the request "authenticated". The
+    minimum API is a `is_authenticated` method.
     """
 
     def is_authenticated(self):  # pylint: disable=no-self-use

--- a/courses/authentication.py
+++ b/courses/authentication.py
@@ -1,0 +1,43 @@
+"""
+Provides key authentication capability to django-rest-framework.
+"""
+from django.conf import settings
+from rest_framework import authentication, exceptions
+
+
+class ValidUser(object):
+    """
+    Represents a valid user for login purposes.
+    """
+
+    def is_authenticated(self):  # pylint: disable=no-self-use
+        """Always yes."""
+        return True
+
+
+class KeyAuthentication(authentication.BaseAuthentication):
+    """
+    Class which checks that incoming tokens match an allowed set of
+    client keys. Allowed client keys are found in the
+    CCXCON_ALLOWED_CLIENT_KEYS setting.
+    """
+    def authenticate(self, request):
+        """
+        Authenticates the user. returns (user, token), but we don't do
+        users in CCXCon, so we only return the token.
+        """
+        if 'HTTP_AUTHORIZATION' not in request.META:
+            return None
+
+        auth = request.META['HTTP_AUTHORIZATION']
+        if not auth:
+            return None
+
+        scheme, token = auth.split(" ")
+        if scheme != "Token":
+            return None
+
+        if token not in settings.CCXCON_ALLOWED_CLIENT_KEYS:
+            raise exceptions.AuthenticationFailed('Unknown token')
+
+        return (ValidUser(), token)

--- a/courses/tests/test_api.py
+++ b/courses/tests/test_api.py
@@ -1,6 +1,7 @@
 """Tests regarding REST API"""
 import json
 
+from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 
@@ -9,6 +10,38 @@ from courses.factories import CourseFactory, ModuleFactory
 
 class ApiTests(TestCase):
     """Tests regarding REST API"""
+    @staticmethod
+    def _correct_auth_header():
+        """Returns a correct auth header for valid requests"""
+        return "Token {}".format(settings.CCXCON_ALLOWED_CLIENT_KEYS.copy().pop())
+
+    def test_login_required(self):
+        """Returns 403 errors if we didn't pass in a login header."""
+        m1 = ModuleFactory.create()
+        resp = self.client.get(reverse('module-list', args=(m1.course.uuid,)))
+        self.assertEqual(403, resp.status_code)
+
+    def test_invalid_login_prevented(self):
+        """Returns 403 errors if we didn't pass in a known auth key."""
+        m1 = ModuleFactory.create()
+        resp = self.client.get(reverse('module-list', args=(m1.course.uuid,)),
+                               HTTP_AUTHORIZATION="Token asdf")
+        self.assertEqual(403, resp.status_code)
+
+    def test_invalid_login__unknown_scheme(self):
+        """Returns 403 errors if we didn't pass in a known scheme."""
+        m1 = ModuleFactory.create()
+        resp = self.client.get(reverse('module-list', args=(m1.course.uuid,)),
+                               HTTP_AUTHORIZATION="Basic asdf")
+        self.assertEqual(403, resp.status_code)
+
+    def test_valid_login(self):
+        """Returns 200 errors if we did everything correctly."""
+        m1 = ModuleFactory.create()
+        resp = self.client.get(reverse('module-list', args=(m1.course.uuid,)),
+                               HTTP_AUTHORIZATION=ApiTests._correct_auth_header())
+        self.assertEqual(200, resp.status_code)
+
     def test_separate_children(self):
         """
         Test that a course's modules list endpoint doesn't contain modules
@@ -20,7 +53,8 @@ class ApiTests(TestCase):
         # Different courses
         self.assertNotEqual(m1.course, m2.course)
 
-        resp = self.client.get(reverse('module-list', args=(m1.course.uuid,)))
+        resp = self.client.get(reverse('module-list', args=(m1.course.uuid,)),
+                               HTTP_AUTHORIZATION=ApiTests._correct_auth_header())
         payload = json.loads(resp.content.decode('utf-8'))
         self.assertEqual(len(payload), 1)
 
@@ -44,8 +78,10 @@ class ApiTests(TestCase):
             "price_per_seat_cents": 3
         }
         modules_url = reverse('module-list', args=(course.uuid,))
-        resp = self.client.post(modules_url, module_dict)
+        resp = self.client.post(modules_url, module_dict,
+                                HTTP_AUTHORIZATION=ApiTests._correct_auth_header())
         self.assertEqual(resp.status_code, 400)  # Invalid JSON
 
-        resp = self.client.get(modules_url)
+        resp = self.client.get(modules_url,
+                               HTTP_AUTHORIZATION=ApiTests._correct_auth_header())
         self.assertEqual(resp.status_code, 200, resp.content)


### PR DESCRIPTION
Built on top of #19.

Fixes #5 #11 

We're doing a simple token based authentication. Tokens will be added via env vars. Validated this approach with @bdero from a security perspective, which is fine given all communication with be over https.

Dredd tests are excluded from auth. These tests are done in django.
