### PR TITLE
Added Heroku deployment configuration

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: newrelic-admin run-program uwsgi uwsgi.ini

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # CCXCon
 [![Build Status](https://travis-ci.org/mitodl/ccxcon.svg)](https://travis-ci.org/mitodl/ccxcon)
 
+[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
+
+
 CCXCon is a simple API serves as an interface between edX running instances and different MIT apps.
 
 Implements the APIs as described here http://docs.ccxcon.apiary.io/

--- a/app.json
+++ b/app.json
@@ -1,0 +1,74 @@
+{
+    "name": "CCXCON",
+    "description": "CCX Connector",
+    "keywords": [
+        "Django",
+        "Python",
+        "MIT",
+        "Office of Digital Learning",
+        "Open edX",
+        "Custom Courses for edX"
+    ],
+    "website": "https://github.com/mitodl/ccxcon",
+    "repository": "https://github.com/mitodl/ccxcon",
+    "success_url": "/",
+    "scripts": {
+        "postdeploy": "./manage.py migrate"
+    },
+    "addons": [
+        "heroku-postgresql:hobby-dev",
+        "newrelic:wayne"
+    ],
+    "buildpacks": [
+        {
+            "url": "https://github.com/heroku/heroku-buildpack-python"
+        }
+    ],
+    "env": {
+        "ALLOWED_HOSTS": {
+            "description": "Array of allowed hostnames",
+            "default":  "['*']"
+        },
+        "CCXCON_ADMIN_EMAIL": {
+            "description": "E-mail to send 500 reports to.",
+            "required": false
+        },
+        "CCXCON_EMAIL_HOST": {
+            "description": "Outgoing e-mail settings",
+            "required": false
+        },
+        "CCXCON_EMAIL_PASSWORD": {
+            "description": "Outgoing e-mail settings",
+            "required": false
+        },
+        "CCXCON_EMAIL_PORT": {
+            "description": "Outgoing e-mail settings",
+            "required": false,
+            "value":  "587"
+        },
+        "CCXCON_EMAIL_TLS": {
+            "description": "Outgoing e-mail settings",
+            "required": false,
+            "value":  "True"
+        },
+        "CCXCON_EMAIL_USER": {
+            "description": "Outgoing e-mail settings",
+            "required": false
+        },
+        "CCXCON_FROM_EMAIL": {
+            "description": "E-mail to use for the from field"
+
+        },
+        "CCXCON_SUPPORT_EMAIL": {
+            "description": "E-mail address for support e-mails."
+        },
+        "NEW_RELIC_APP_NAME": {
+            "description": "Application identifier in New Relic.",
+            "default": "CCX Connector"
+        },
+        "SECRET_KEY": {
+            "description": "Django secret key.",
+            "generator": "secret"
+        }
+    }
+}

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -1,0 +1,11 @@
+[uwsgi]
+http-socket = :$(PORT)
+master = true
+processes = 5
+die-on-term = true
+wsgi-file = ccxcon/wsgi.py
+memory-report = true
+pidfile=/tmp/ccxcon-mast.pid
+vacuum=True
+enable-threads = true
+single-interpreter = true


### PR DESCRIPTION
This set of changes adds the necessary pieces for continuous deployment (as well as automated deployment of new environments) on Heroku.

The uwsgi config includes the following lines for compatibility with the New Relic python agent for monitoring:

```
enable-threads = true
single-interpreter = true
```

See this resource for a detailed explanation of these two lines: https://docs.newrelic.com/docs/agents/python-agent/hosting-mechanisms/python-agent-uwsgi#mandatory-options

Closes #25.
Closes #26.
