### PR TITLE
Upgrade pylint to fix build failures.

### DIFF
--- a/courses/models.py
+++ b/courses/models.py
@@ -1,10 +1,11 @@
 """
 Models necessary to represent a course catalog.
 """
+import uuid as pyuuid
+
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
 from jsonfield import JSONField
-import uuid as pyuuid
 
 
 @python_2_unicode_compatible

--- a/courses/serializers.py
+++ b/courses/serializers.py
@@ -2,6 +2,7 @@
 Django Rest Framework Serializers for Course API
 """
 import json
+import logging
 
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import reverse
@@ -11,7 +12,6 @@ import six
 
 from .models import Course, Module, EdxAuthor
 
-import logging
 log = logging.getLogger(__name__)
 
 

--- a/courses/tests/test_dredd.py
+++ b/courses/tests/test_dredd.py
@@ -2,8 +2,9 @@
 Test driver for Dredd
 """
 import os
-from six.moves import urllib_parse as urlparse
 import subprocess
+
+from six.moves import urllib_parse as urlparse
 
 from django.conf import settings
 from django.test import LiveServerTestCase

--- a/courses/tests/test_fields.py
+++ b/courses/tests/test_fields.py
@@ -21,21 +21,21 @@ class JsonListFieldTests(TestCase):
         Test that empty list string decodes properly
         """
         f = JLF()
-        self.assertEquals([], f.to_internal_value('[]'))
+        self.assertEqual([], f.to_internal_value('[]'))
 
     def test_decodes_unicode(self):
         """
         Test that empty list unicode string decodes properly
         """
         f = JLF()
-        self.assertEquals([], f.to_internal_value(u'[]'))
+        self.assertEqual([], f.to_internal_value(u'[]'))
 
     def test_handles_decoding_nullable_values(self):
         """
         Test that null is decoded to None
         """
         f = JLF()
-        self.assertEquals(None, f.to_internal_value('null'))
+        self.assertEqual(None, f.to_internal_value('null'))
 
     def test_throws_validationerror_on_invalid_json(self):
         """

--- a/courses/views.py
+++ b/courses/views.py
@@ -40,7 +40,7 @@ class ModuleViewSet(viewsets.ModelViewSet):
             'course-detail', args=(kwargs['uuid_uuid'],))
         return super(ModuleViewSet, self).update(request, **kwargs)
 
-    def list(self, request, uuid_uuid, *args, **kwargs):
+    def list(self, request, uuid_uuid):
         "List of modules filtered by parent course."
         modules = self.queryset.filter(course__uuid=uuid_uuid)
         serializer = self.serializer_class(

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,5 +1,5 @@
 tox==2.2.1
-pylint==1.4.4
+pylint==1.5.0
 pytest==2.8.2
 pytest-cov==2.2.0
 pytest-django==2.9.1


### PR DESCRIPTION
Pylint 1.4.4 began failing in a strange way due to in internal issue, as seen in this build:
https://travis-ci.org/mitodl/ccxcon/builds/93938851

This PR upgrades to 1.5 to fix the problem, and removes new pylint violations.
