### PR TITLE
Adding oauth2 provider to ccxcon.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@
 
 CCXCon is a simple API serves as an interface between edX running instances and different MIT apps.
 
+At a high level, it takes information from multiple edX backends, and
+produces a single data stream. Going the other way, it takes data
+along this same single data stream and will route it to the correct
+edX backend.
+
 Implements the APIs as described here http://docs.ccxcon.apiary.io/
 
 ## Setup
@@ -17,8 +22,19 @@ pip install docker-compose
 docker-compose up
 ```
 
-From there, you can visit the minimal web-ui at http://localhost:8077/
+From there, you can visit the minimal web-ui at https://localhost:8077/
 
 ## Tests
 
 You can run the dredd API tests via the command `docker-compose up dredd`.
+
+
+## Authorization
+
+To be authorized to make requests to CCXCon, you use OAuth2. OAuth2
+clients can be made in the django-admin. If you're doing
+server-to-server oauth (edX and teachers' portal cases), you'll want
+to create a user representing them, and an oauth app tied to that
+user. The Authorization type should be "Client Credentials". You can
+read more about that in the
+[OAuth2 spec](https://tools.ietf.org/html/rfc6749#section-4.4).

--- a/ccxcon/settings.py
+++ b/ccxcon/settings.py
@@ -79,6 +79,8 @@ INSTALLED_APPS = (
     'django.contrib.staticfiles',
 
     'rest_framework',
+    'oauth2_provider',
+    'sslserver',
 
     'courses',
 

--- a/ccxcon/urls.py
+++ b/ccxcon/urls.py
@@ -20,6 +20,7 @@ urlpatterns = [
     url(r'^api/v1/', include(router.urls)),
     url(r'^api/v1/', include(modules_router.urls)),
     url(r'^api/v1/user_exists/$', 'courses.views.user_existence', name='user-existence'),
+    url(r'^o/', include('oauth2_provider.urls', namespace='oauth2_provider')),
 ]
 
 urlpatterns += staticfiles_urlpatterns()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ web:
     /bin/bash -c '
     sleep 3 &&
     python manage.py migrate --noinput &&
-    python manage.py runserver 0.0.0.0:8077'
+    python manage.py runsslserver 0.0.0.0:8077'
   volumes:
     - .:/src
   environment:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ six==1.10.0
 PyYAML==3.11
 newrelic==2.54.0.41
 whitenoise==2.0.6
+django-oauth-toolkit==0.9.0
+django-sslserver==0.16


### PR DESCRIPTION
We require this to run over https, the OAuth2 spec mandates the use of
TLS. This will result in invalid certificate warnings locally, but this
shouldn't be the case in production.

You can test that this works with the following script. You will need to set up a client and change those values in the script.

``` python
import requests
from oauthlib.oauth2 import BackendApplicationClient
from requests_oauthlib import OAuth2Session

CLIENT_ID=""
CLIENT_SECRET=""

TOKEN_URL="https://localhost:8077/o/token/"

client = BackendApplicationClient(client_id=CLIENT_ID)
oauth = OAuth2Session(client=client)
token = oauth.fetch_token(token_url=TOKEN_URL,
                          client_id=CLIENT_ID,
                          client_secret=CLIENT_SECRET,
                          verify=False)

print "TOKEN: {}".format(token)
```

Fixes #40 
Refs https://github.com/mitodl/teachersportal/issues/23
Refs #11 
Refs #5 (login mechanism, but not authorization layer)
