### PR TITLE
Added linter for autospec always on mock.patch

### DIFF
--- a/ccxcon/tests/test_settings.py
+++ b/ccxcon/tests/test_settings.py
@@ -40,7 +40,7 @@ class TestSettings(TestCase):
         with open(temp_config_path, 'w') as temp_config:
             temp_config.write(yaml.dump(config_settings))
 
-        with mock.patch('ccxcon.settings.CONFIG_PATHS') as config_paths:
+        with mock.patch('ccxcon.settings.CONFIG_PATHS', autospec=True) as config_paths:
             config_paths.__iter__.return_value = [temp_config_path]
             fallback_config = load_fallback()
             self.assertDictEqual(fallback_config, config_settings)

--- a/lint.sh
+++ b/lint.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -x
+RETVAL=0
+
+function incr_err() {
+    RETVAL=`expr $RETVAL + 1`
+}
+
+OUTPUT=`git grep "patch(" | grep -v "autospec"`
+if [ $(echo -n $OUTPUT| wc -l) -eq 0 ]; then
+    echo "Autospec check.. DONE"
+else
+    echo "All mock.patch calls must use autospec=True"
+    echo $OUTPUT
+    incr_err
+fi
+
+
+exit $RETVAL

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ deps =
   -r{toxinidir}/test_requirements.txt
 commands =
     py.test {posargs}
+    ./lint.sh
 passenv = *
 setenv =
     CCXCON_DB_DISABLE_SSL=True


### PR DESCRIPTION
#### What's this PR do?

Adds a linter so we don't miss autospec=True in our mock.patch's.
#### How should this be manually tested?

Erase the autospec line I fixed. It will return a 1 status code.
#### Any background context you want to provide?

> Peter Wilkins·2:42 PM
> We've been bitten in at least one other ODLEng project by _not_ using autospec.
#### What are the relevant tickets?
#### What gif best describes this PR or how it makes you feel?

![](http://stream1.gifsoup.com/view/86971/santa-checking-list-o.gif)
