### PR TITLE
Made sslserver django 1.9 compatible

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,6 @@ PyYAML==3.11
 newrelic==2.54.0.41
 whitenoise==2.0.6
 django-oauth-toolkit==0.9.0
-django-sslserver==0.16
+django-sslserver==0.18
 requests==2.8.1
 redis==2.10.5


### PR DESCRIPTION
See https://github.com/teddziuba/django-sslserver/pull/40 for upstream issue.
