### PR TITLE
Faster Travis Builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
-# Set Go as the language so it doesn't download the pip things. Instead, let docker do that.
-language: go
+# Set Ruby as the language so it doesn't download the pip things. Instead, let docker do that.
+language: ruby
+cache: bundler
 script:
   - docker-compose run -e TOX_WORK_DIR=/tmp -e COVERAGE_DIR=/tmp web tox
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-language: python
+# Set Go as the language so it doesn't download the pip things. Instead, let docker do that.
+language: go
 script:
   - docker-compose run -e TOX_WORK_DIR=/tmp -e COVERAGE_DIR=/tmp web tox
 services:


### PR DESCRIPTION
#### What's this PR do?

Makes our travis build ~40 seconds faster.
#### Any background context you want to provide?

We are installing python dependencies 4 times currently. This brings it down to three. Once on docker container creation and once for each tox instance.

Compare the timing on: [Ruby Version](https://travis-ci.org/mitodl/ccxcon/builds/96056495#L134) [Python Version](https://travis-ci.org/mitodl/ccxcon/builds/96055553#L123)
#### What gif best describes this PR or how it makes you feel?

![](http://24.media.tumblr.com/1e88483b3d8860f3867897ccbd06dcb8/tumblr_myc0ygGR2l1rwg7ino1_400.gif)
