### PR TITLE
Added linter to check for autogenerated migrations

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -1,12 +1,13 @@
-#!/bin/bash -x
+#!/bin/bash
 RETVAL=0
 
 function incr_err() {
     RETVAL=`expr $RETVAL + 1`
 }
 
+# check that mock.patch calls use autospec
 OUTPUT=`git grep "patch(" | grep -v "autospec"`
-if [ $(echo -n $OUTPUT| wc -l) -eq 0 ]; then
+if [ "$OUTPUT" = "" ]; then
     echo "Autospec check.. DONE"
 else
     echo "All mock.patch calls must use autospec=True"
@@ -14,5 +15,14 @@ else
     incr_err
 fi
 
+# Ensure auto-generated migrations are renamed.
+OUTPUT=`find .  | grep -v tox | grep -E "migrations/.*auto.*py$"`
+if [ "$OUTPUT" = "" ]; then
+    echo "Migration naming check.. DONE"
+else
+    echo "You must rename auto migrations to something sensible."
+    echo $OUTPUT
+    incr_err
+fi
 
 exit $RETVAL


### PR DESCRIPTION
#### What's this PR do?

Adds a linter to check for un-renamed migrations.
#### Where should the reviewer start?

`lint.sh`
#### How should this be manually tested?

Alter a django model. Type `docker-compose run web ./manage.py makemigrations` The linter should then fail. Renaming the file, the linter will pass.
#### Any background context you want to provide?

I keep getting this feedback in code review, so let's off load this group knowledge onto a reusable script.

For bash docs on string comparison (to validate this works)
http://tldp.org/LDP/abs/html/comparison-ops.html#SCOMPARISON1
#### What are the relevant tickets?
#### Screenshots (if appropriate)

![screenshot from 2015-12-10 14-49-14](https://cloud.githubusercontent.com/assets/3853/11726569/35109740-9f4d-11e5-8b68-c30de9a37f28.png)
#### What gif best describes this PR or how it makes you feel?

https://media.giphy.com/media/at58FobBELMWc/giphy.gif
