### PR TITLE
Moved factory_boy to requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update &&\
     apt-get install -y $(grep -vE "^\s*#" apt.txt  | tr "\n" " ") &&\
     ln -s /usr/bin/nodejs /usr/bin/node &&\
     pip install pip --upgrade &&\
-    npm install -g dredd
+    npm install -g dredd@1.0.1
 
 # Add non-root user.
 RUN adduser --disabled-password --gecos "" mitodl

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ django-sslserver==0.18
 requests==2.8.1
 redis==2.10.5
 fake-factory==0.5.3
+factory_boy==2.6.0

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -5,7 +5,6 @@ pytest-cov==2.2.0
 pytest-django==2.9.1
 pytest-pep8==1.0.6
 pytest-pylint==0.4.0
-factory_boy==2.6.0
 semantic-version==2.4.2
 mock==1.3.0
 ipython


### PR DESCRIPTION
Because factory_boy is a dependency of the `gen_fake_data` management command. @noisecapella 
