### PR TITLE
Added SSL redirect setting

### DIFF
--- a/app.json
+++ b/app.json
@@ -69,6 +69,11 @@
         "SECRET_KEY": {
             "description": "Django secret key.",
             "generator": "secret"
+        },
+        "CCXCON_SECURE_SSL_REDIRECT": {
+            "description": "Application-level SSL recirect setting.",
+	    "required": false,
+	    "value": "True"
         }
     }
 }

--- a/ccxcon/settings.py
+++ b/ccxcon/settings.py
@@ -67,6 +67,9 @@ DEBUG = get_var('DEBUG', False)
 
 ALLOWED_HOSTS = get_var('ALLOWED_HOSTS', [])
 
+# SECURITY WARNING: Always turn on SSL redirect in production
+SECURE_SSL_REDIRECT = get_var('CCXCON_SECURE_SSL_REDIRECT', True)
+
 
 # Application definition
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ web:
     CCXCON_CAS_URL:
     TOX_WORK_DIR: .tox
     COVERAGE_DIR: htmlcov
+    CCXCON_SECURE_SSL_REDIRECT: False
   ports:
     - "8077:8077"
   links:


### PR DESCRIPTION
It's enabled by default for production, but disabled by default by docker-compose for local development. 

Not sure if we should just enable it for local development, since the certificate validation trickery is required to test oauth anyhow.
