### PR TITLE
Added quotes to SSL redirect var value

### DIFF
--- a/app.json
+++ b/app.json
@@ -72,8 +72,8 @@
         },
         "CCXCON_SECURE_SSL_REDIRECT": {
             "description": "Application-level SSL recirect setting.",
-	    "required": false,
-	    "value": "True"
+            "required": false,
+            "value": "True"
         }
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ web:
     CCXCON_CAS_URL:
     TOX_WORK_DIR: .tox
     COVERAGE_DIR: htmlcov
-    CCXCON_SECURE_SSL_REDIRECT: False
+    CCXCON_SECURE_SSL_REDIRECT: 'False'
   ports:
     - "8077:8077"
   links:


### PR DESCRIPTION
There's a deprecation warning about it.
