### PR TITLE
Endpoint for creating CCXs on edX

### DIFF
--- a/ccxcon/urls.py
+++ b/ccxcon/urls.py
@@ -20,6 +20,7 @@ urlpatterns = [
     url(r'^api/v1/', include(router.urls)),
     url(r'^api/v1/', include(modules_router.urls)),
     url(r'^api/v1/user_exists/$', 'courses.views.user_existence', name='user-existence'),
+    url(r'^api/v1/ccx/$', 'courses.views.create_ccx', name='create-ccx'),
     url(r'^o/', include('oauth2_provider.urls', namespace='oauth2_provider')),
 ]
 

--- a/courses/factories.py
+++ b/courses/factories.py
@@ -9,6 +9,7 @@ import faker
 from .models import Module, Course, EdxAuthor
 from oauth_mgmt.factories import BackingInstanceFactory
 
+
 fake = faker.Factory.create()
 
 


### PR DESCRIPTION
#### What's this PR do?

This adds an API endpoint to create CCXs on edX.

This is based on the branch #89. You can see the relatively small delta between those here: https://github.com/mitodl/ccxcon/compare/course-structure-query...create-ccx-endpoint
#### Where should the reviewer start?

courses/views.py
#### How should this be manually tested?
1. Create an OAuth client, grant, user, master course (with ccx enabled) on edx. You can see instructions for how to do this on #89.
2. Create an access token for a user on ccxcon. You can do this [here](https://localhost.daplie.com:8077/admin/oauth2_provider/accesstoken/add/)
3. Issue the following curl command:
   
   ```
   curl -v -L -X POST \
     -H "Authorization: Bearer test-token" \
     https://localhost.daplie.com:8077/api/v1/ccx/ \
     -d "master_course_id=course-    v1:edX%2BDemoX%2BDemo_Course&user_email=verified@example.com&total_seats=30&display_    name=test_name_here"
   ```
   
   You may want to change some of these values, including:
   - `test-token` to the access token you generated above.
   - `master_course_id` to the id of the course you want to duplicate. You need to escape the +'s via     `%2B`.
   - `user_email` to the user you want to be given access
   - `total_seats` for how many people you want to register
   - `display_name` to the name of the resulting CCX course.
4. Login as the user you chose for step 3 and see if you have ccx coach access.
#### Any background context you want to provide?

This requires having Giovanni's branch `gdm_feature_ccx_actual_apis_#119` setup on edX.
#### What are the relevant tickets?

Fixes #78 
#### What gif best describes this PR or how it makes you feel?

![](https://media.giphy.com/media/Ap7t9YOLvTv6U/giphy.gif)
