### PR TITLE
Webhook fixes

### DIFF
--- a/apiary_hooks.py
+++ b/apiary_hooks.py
@@ -1,4 +1,5 @@
 """Hooks for dredd tests."""
+from uuid import UUID
 from datetime import datetime, timedelta
 
 import django
@@ -16,8 +17,8 @@ from courses.factories import CourseFactory  # noqa
 from courses.models import Course, Module  # noqa
 
 
-COURSE_UUID = '7e0e52d0386411df81ce001b631bdd31'
-MODULE_UUID = '1db1a8439cbf4a8f8c395ad63fb43e8a'
+COURSE_UUID = UUID(hex='7e0e52d0386411df81ce001b631bdd31')
+MODULE_UUID = UUID(hex='1db1a8439cbf4a8f8c395ad63fb43e8a')
 
 dummyCourse = dict(
     uuid=COURSE_UUID,

--- a/ccxcon/settings.py
+++ b/ccxcon/settings.py
@@ -234,6 +234,18 @@ LOGGING = {
             'handlers': ['console', 'syslog'],
             'level': LOG_LEVEL,
         },
+        'webhooks': {
+            'handlers': ['console', 'syslog'],
+            'level': LOG_LEVEL,
+        },
+        'courses': {
+            'handlers': ['console', 'syslog'],
+            'level': LOG_LEVEL,
+        },
+        'oauth_mgmt': {
+            'handlers': ['console', 'syslog'],
+            'level': LOG_LEVEL,
+        },
         'django': {
             'propagate': True,
             'level': DJANGO_LOG_LEVEL,

--- a/courses/management/commands/gen_fake_data.py
+++ b/courses/management/commands/gen_fake_data.py
@@ -6,6 +6,7 @@ from django.core.management import BaseCommand
 
 from courses.factories import CourseFactory, ModuleFactory
 from oauth_mgmt.factories import BackingInstanceFactory
+from oauth_mgmt.models import BackingInstance
 
 
 class Command(BaseCommand):
@@ -31,7 +32,10 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         record_count = 0
-        bi = BackingInstanceFactory.create(instance_url='https://edx.org')
+        try:
+            bi = BackingInstance.objects.get(instance_url='https://edx.org')
+        except BackingInstance.DoesNotExist:
+            bi = BackingInstanceFactory.create(instance_url='https://edx.org')
         for _ in range(int(options['courses'])):
             course = CourseFactory.create(edx_instance=bi)
             record_count += 1

--- a/courses/models.py
+++ b/courses/models.py
@@ -86,7 +86,7 @@ class Module(models.Model):
             'title': self.title,
             'external_pk': str(self.uuid),
             'subchapters': self.subchapters,
-            'course_external_pk': self.course.uuid,
+            'course_external_pk': str(self.course.uuid),
         }
 
 

--- a/courses/models_test.py
+++ b/courses/models_test.py
@@ -1,6 +1,7 @@
 """
 Tests for Models
 """
+import json
 from django.test import TestCase
 from django.contrib.auth.models import User
 
@@ -18,6 +19,16 @@ class CourseTests(TestCase):
         Test behavior of str(Course)
         """
         assert str(Course(title='test')) == 'test'
+
+    def test_towebhook(self):
+        """
+        test to_webhook implementation returns valid json object
+        """
+        course = CourseFactory.build()
+        json.dumps(course.to_webhook())
+        ex_pk = course.to_webhook()['external_pk']
+        assert isinstance(ex_pk, str)
+        assert '-' in ex_pk
 
 
 class ModuleTests(TestCase):
@@ -46,6 +57,17 @@ class ModuleTests(TestCase):
         result = [x.id for x in Module.objects.all()]
 
         assert result == [m10.id, m11.id, m20.id, m21.id]
+
+    def test_towebhook(self):
+        """
+        test to_webhook implementation returns valid json object
+        """
+        module = ModuleFactory.build()
+        web_out = module.to_webhook()
+        json.dumps(web_out)
+        for k in ('external_pk', 'course_external_pk'):
+            assert isinstance(web_out[k], str)
+            assert '-' in web_out[k]
 
 
 class UserInfoTests(TestCase):

--- a/courses/signals.py
+++ b/courses/signals.py
@@ -19,7 +19,7 @@ def publish_on_update(sender, instance, **kwargs):
     publish_webhook.delay(
         '{}.{}'.format(instance._meta.app_label,
                        instance._meta.object_name),
-        'uuid', instance.uuid)
+        'uuid', str(instance.uuid))
 
 
 @receiver(post_save, sender=User)

--- a/courses/signals_test.py
+++ b/courses/signals_test.py
@@ -28,7 +28,7 @@ class PublishOnUpdateTests(TestCase):
             args, _ = wh_mock.delay.call_args
             assert args[0] == 'courses.Course'
             assert args[1] == 'uuid'
-            assert args[2] == course.uuid
+            assert args[2] == str(course.uuid)
 
     def test_module_save_publishes(self):
         """
@@ -42,7 +42,7 @@ class PublishOnUpdateTests(TestCase):
             args, _ = wh_mock.delay.call_args
             assert args[0] == 'courses.Module'
             assert args[1] == 'uuid'
-            assert args[2] == module.uuid
+            assert args[2] == str(module.uuid)
 
 
 class CreateProfileTests(TestCase):

--- a/courses/views.py
+++ b/courses/views.py
@@ -18,6 +18,7 @@ from .models import Course, Module, EdxAuthor
 from .serializers import CourseSerializer, ModuleSerializer
 from .tasks import module_population
 
+
 log = logging.getLogger(__name__)
 
 
@@ -163,7 +164,7 @@ def create_ccx(request):
         return upstream_error(resp.content)
 
     log.info(
-        'Created ccx course for user {email} on master course {course_id}. Response: {response}',
-        email=user_email, course_id=master_course_id, response=resp.content)
+        'Created ccx course for user %s on master course %s. Response: %s',
+        user_email, master_course_id, resp.content)
 
     return Response(status=201)

--- a/webhooks/tasks.py
+++ b/webhooks/tasks.py
@@ -81,7 +81,9 @@ def publish_webhook(model_str, lookup_field, lookup_value):
             j_payload = json.dumps(payload)
             signature = hmac.new(force_bytes(wh.secret), force_bytes(j_payload),
                                  hashlib.sha1).hexdigest()
-            requests.post(wh.url, json=j_payload, headers={
+            log.debug("Posting payload with signature %s. Payload: %s", signature, j_payload)
+            # NOTE: Using the non-stringy version, given we're posting this as json.
+            requests.post(wh.url, json=payload, headers={
                 'X-CCXCon-Signature': signature
             })
         except RequestException as e:

--- a/webhooks/tasks_test.py
+++ b/webhooks/tasks_test.py
@@ -48,7 +48,8 @@ class PublishWebhookTests(TestCase):
             publish_webhook('courses.Course', 'pk', course.pk)
             assert mock_requests.post.call_count == 1
             _, kwargs = mock_requests.post.call_args
-            payload = json.loads(kwargs['json'])
+            payload = kwargs['json']
+            assert isinstance(payload, dict)
             assert payload['action'] == 'update'
 
     def test_no_post_if_no_webhook_method(self):
@@ -70,8 +71,7 @@ class PublishWebhookTests(TestCase):
             publish_webhook('courses.Course', 'pk', 1)
             assert mock_requests.post.call_count == 1
             _, kwargs = mock_requests.post.call_args
-            payload = json.loads(kwargs['json'])
-            assert payload['action'] == 'delete'
+            assert kwargs['json']['action'] == 'delete'
 
     def test_secure_header_verification(self):
         """
@@ -83,14 +83,13 @@ class PublishWebhookTests(TestCase):
             publish_webhook('courses.Course', 'pk', course.pk)
             assert mock_requests.post.call_count == 1
             _, kwargs = mock_requests.post.call_args
-            payload = json.loads(kwargs['json'])
-            assert payload['action'] == 'update'
+            assert kwargs['json']['action'] == 'update'
 
             # This constant_time_compare is important for implementations to
             # ensure they're not vulnerable to timing attacks.
             assert constant_time_compare(
                 kwargs['headers']['X-CCXCon-Signature'], hmac.new(
-                    force_bytes(wh.secret), force_bytes(kwargs['json']),
+                    force_bytes(wh.secret), force_bytes(json.dumps(kwargs['json'])),
                     hashlib.sha1).hexdigest())
 
     def test_one_post_of_many_failing(self):


### PR DESCRIPTION
There were a few issues with webhooks.
1. They wouldn't serialize (see to-webhook tests)
2. They were sending json encoded as a string, rather than the actual json object.
3. There wasn't enough logging to detect errors.

Based on #95

See differences here:
https://github.com/mitodl/ccxcon/compare/create-ccx-endpoint...webhook-fixes
