### PR TITLE
Enabled redis in the web container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,10 +29,14 @@ web:
     TOX_WORK_DIR: .tox
     COVERAGE_DIR: htmlcov
     CCXCON_SECURE_SSL_REDIRECT: 'False'
+    CELERY_ALWAYS_EAGER: 'False'
+    CELERY_RESULT_BACKEND: redis://redis:6379/4
+    BROKER_URL: redis://redis:6379/4
   ports:
     - "8077:8077"
   links:
     - db
+    - redis
 celery:
   image: ccxcon_web
   command: >

--- a/tox.ini
+++ b/tox.ini
@@ -14,3 +14,4 @@ commands =
 passenv = *
 setenv =
     CCXCON_DB_DISABLE_SSL=True
+    CELERY_ALWAYS_EAGER=True


### PR DESCRIPTION
Made Redis available in the web container even if `CELERY_ALWAYS_EAGER` is still set to `True`

Requirement for #29 

Fixes #98 
