### PR TITLE
rc/0.2.0

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,8 @@
+
+Release Notes
+=============
+
+Version 0.1.0
+-------------
+
+- Initial release

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,29 @@
+Release Notes
+=============
+
+Version 0.2.0
+=============
+
+- Added missing release_notes template files.
+- Changed to ``django-server-status``.
+- Added logging message for webhooks with non-200 responses.
+- Removed ``dredd``, removed unused HTTP methods from API, added unit tests.
+- Added generator script for life-like data.
+- Implemented receiving JSON on ``create-ccx`` endpoint.
+- Added support for course modules.
+- Fixed ``requests`` installation.
+- Added additional logging.
+- Incoming requests send uuids, not course ids.
+- Included the course/module's instance in webhook.
+- disabled SSL being necessary for celery.
+- Added status.
+- Enabled ``redis`` in the web container.
+- Made webhook fixes.
+- Added API endpoint to create ccxs on edX.
+- Now fetching module listing through course structure api.
+
+Version 0.1.0
+-------------
+
+- Initial release
+

--- a/ccxcon/settings.py
+++ b/ccxcon/settings.py
@@ -16,7 +16,7 @@ import yaml
 
 import dj_database_url
 
-VERSION = "0.0.0"
+VERSION = "0.1.0"
 
 CONFIG_PATHS = [
     os.environ.get('CCXCON_CONFIG', ''),

--- a/ccxcon/settings.py
+++ b/ccxcon/settings.py
@@ -16,7 +16,7 @@ import yaml
 
 import dj_database_url
 
-VERSION = "0.0.0"
+VERSION = "0.2.0"
 
 CONFIG_PATHS = [
     os.environ.get('CCXCON_CONFIG', ''),

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='ccxcon',
-    version='0.0.0',
+    version='0.2.0',
     license='AGPLv3',
     author='MIT ODL Engineering',
     author_email='odl-engineering@mit.edu',


### PR DESCRIPTION
### Release Version 0.2.0
- Added missing release_notes template files.
- Changed to `django-server-status`.
- Added logging message for webhooks with non-200 responses.
- Removed `dredd`, removed unused HTTP methods from API, added unit tests.
- Added generator script for life-like data.
- Implemented receiving JSON on `create-ccx` endpoint.
- Added support for course modules.
- Fixed `requests` installation.
- Added additional logging.
- Incoming requests send uuids, not course ids.
- Included the course/module's instance in webhook.
- disabled SSL being necessary for celery.
- Added status.
- Enabled `redis` in the web container.
- Made webhook fixes.
- Added API endpoint to create ccxs on edX.
- Now fetching module listing through course structure api.
