### PR TITLE
Added script to create CCX on edx through CCXCon

### DIFF
--- a/create_ccx.py
+++ b/create_ccx.py
@@ -1,0 +1,112 @@
+"""
+Script to create a CCX using the CCXCon REST APIs
+"""
+
+import argparse
+import sys
+
+from oauthlib.oauth2 import BackendApplicationClient
+from requests_oauthlib import OAuth2Session
+
+HTTP_201_CREATED = 201
+CCXCON_TOKEN_URL = '/o/token/'
+CCXCON_CREATE_CCX = '/api/v1/ccx/'
+
+
+def parse_arguments():
+    """
+    Parsing arguments necessary to create the CCX
+    """
+    parser = argparse.ArgumentParser(description="Create a CCX using CCXCon")
+    # Parameters for CCXCon information
+    parser.add_argument('--ccxcon-url', dest='ccxconurl',
+                        help="The CCXCon URL to be used", required=True)
+    parser.add_argument('--client-id', dest='clientid',
+                        help="The user's OAUTH ID", required=True)
+    parser.add_argument('--client-secret', dest='clientsecret',
+                        help="The user's OAUTH SECRET", required=True)
+    # Parameters for creating the CCX
+    parser.add_argument('--master-course', dest='mastercourse',
+                        help="The master course UUID", required=True)
+    parser.add_argument('--user-email', dest='useremail',
+                        help="The coach email", required=True)
+    parser.add_argument('--seats', type=int, dest='seats',
+                        help="The number of seats for the CCX", required=True)
+    parser.add_argument('--ccx-title', dest='ccxtitle',
+                        help="The title for the CCX", required=True)
+    parser.add_argument('--modules', dest='modules', nargs="*",
+                        help="Course modules")
+    # Parameters for the script
+    parser.add_argument('--no-cert-verify', dest='certverify', action='store_false',
+                        default=True, help="No SSL certificate verification")
+    return parser.parse_args()
+
+
+def _get_oauth_client(ccxcon_url, client_id, client_secret, cert_verify):
+    """
+    Function that creates an oauth client and fetches a token.
+    """
+    client = BackendApplicationClient(client_id=client_id)
+    oauth_ccxcon = OAuth2Session(client=client)
+    oauth_ccxcon.fetch_token(
+        token_url="{}{}".format(ccxcon_url.rstrip('/'), CCXCON_TOKEN_URL),
+        client_id=client_id,
+        client_secret=client_secret,
+        verify=cert_verify
+    )
+    return oauth_ccxcon
+
+
+# pylint: disable=too-many-arguments
+def create_ccx_through_ccxcon(ccxcon_url, client_id, client_secret,
+                              master_course_uuid, user_email, seats, ccx_title,
+                              course_modules=None, cert_verify=True):
+    """
+    Creates a CCX using the CCXCon
+    """
+    oauth_ccxcon = _get_oauth_client(ccxcon_url, client_id, client_secret, cert_verify)
+    payload = {
+        'master_course_id': master_course_uuid,
+        'user_email': user_email,
+        'total_seats': seats,
+        'display_name': ccx_title,
+    }
+    if course_modules is not None:
+        payload['course_modules'] = course_modules
+    headers = {'content-type': 'application/json'}
+
+    # make the POST request
+    resp = oauth_ccxcon.post(
+        url="{}{}".format(ccxcon_url.rstrip('/'), CCXCON_CREATE_CCX),
+        json=payload,
+        headers=headers,
+        verify=cert_verify
+    )
+    # pylint: disable=superfluous-parens
+    if resp.status_code != HTTP_201_CREATED:
+        print('Server returned unexpected status code {}'.format(resp.status_code))
+        sys.exit(1)
+    print('CCX successfully created')
+
+
+def main():
+    """
+    Entry point for the script
+    """
+    args = parse_arguments()
+
+    create_ccx_through_ccxcon(
+        args.ccxconurl,
+        args.clientid,
+        args.clientsecret,
+        args.mastercourse,
+        args.useremail,
+        args.seats,
+        args.ccxtitle,
+        args.modules,
+        args.certverify
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ redis==2.10.5
 fake-factory==0.5.3
 factory_boy==2.6.0
 django-server-status==0.2
+requests-oauthlib==0.6.0


### PR DESCRIPTION
#### What are the relevant tickets?

fixes #133 
#### What's this PR do?

It introduces a new script to manually create a CCX using the CCXCon REST APIs
#### Where should the reviewer start?

`create_ccx.py`
#### How should this be manually tested?

To manually test this script you need point it to a CCXCon instance that is talking to an EDX instance.
The CCXCon instance should have already a course pushed by the EDX instance and should be configured to access the EDX instance (meaning the "Backing instance" should contain a proper client ID and secret EDX and the Master course should have as `staff` the user connected to the client ID and secret just mentioned).
You need also to use a virtualenv with the same requirements of CCXCon (in theory only a small subset of requirements are needed)
Once the environment is set, you just need to run the script with the proper parameters.
#### What gif best describes this PR or how it makes you feel?

![](https://giant.gfycat.com/SpryDelightfulGerenuk.gif)
