### PR TITLE
Create CCX view should send a JSON encoded payload

### DIFF
--- a/courses/views.py
+++ b/courses/views.py
@@ -170,7 +170,7 @@ def create_ccx(request):
     try:
         resp = requests.post(
             '{instance}/api/ccx/v0/ccx/'.format(instance=course.edx_instance.instance_url),
-            data=payload,
+            json=payload,
             headers={
                 'Authorization': 'Bearer {}'.format(access_token),
             })


### PR DESCRIPTION
#### What are the relevant tickets?

fixes #134 
#### What's this PR do?

Fixes a bug in the creation of the CCX from CCXCon when a list of modules was passed
#### Where should the reviewer start?

`views.py`
#### How should this be manually tested?

Use the client script to create a CCX and pass some chapters modules.
#### Any background context you want to provide?

You need an EDX instance configured to work with CCXCon
#### What gif best describes this PR or how it makes you feel?

![](http://www.whoateallthepies.tv/wp-content/uploads/2012/12/cazorla.gif)
