### PR TITLE
Replaced string concatenation with urljoin

### DIFF
--- a/courses/tasks.py
+++ b/courses/tasks.py
@@ -1,6 +1,8 @@
 """
 Course Tasks
 """
+from six.moves.urllib.parse import urljoin  # pylint: disable=import-error
+
 import requests
 from requests.exceptions import RequestException
 
@@ -44,9 +46,8 @@ def module_population(self, course_id):
 
     try:
         resp = requests.get(
-            "{instance}/api/courses/v1/blocks/".format(
-                instance=course.edx_instance.instance_url,
-            ), params={
+            urljoin(course.edx_instance.instance_url, '/api/courses/v1/blocks/'),
+            params={
                 "depth": "all",
                 "username": course.edx_instance.username,
                 "course_id": course.course_id,

--- a/courses/views.py
+++ b/courses/views.py
@@ -169,7 +169,7 @@ def create_ccx(request):
 
     try:
         resp = requests.post(
-            '{instance}/api/ccx/v0/ccx/'.format(instance=course.edx_instance.instance_url),
+            parse.urljoin(course.edx_instance.instance_url, '/api/ccx/v0/ccx/'),
             json=payload,
             headers={
                 'Authorization': 'Bearer {}'.format(access_token),

--- a/oauth_mgmt/utils.py
+++ b/oauth_mgmt/utils.py
@@ -2,6 +2,7 @@
 Utility functions.
 """
 from datetime import timedelta
+from six.moves.urllib.parse import urljoin  # pylint: disable=import-error
 
 from django.utils.timezone import now
 import requests
@@ -46,7 +47,7 @@ def get_access_token(instance):
         }
 
     resp = requests.post(
-        "{instance}/oauth2/access_token/".format(instance=instance.instance_url),
+        urljoin(instance.instance_url, '/oauth2/access_token/'),
         data=params)
     if resp.status_code >= 300:
         raise UnretrievableToken(


### PR DESCRIPTION
#### What are the relevant tickets?

Fixes #138 
#### What's this PR do?

Replaces an instance of string concatenation with `urljoin`
#### How should this be manually tested?

Behavior should not change, in particular:
- You should be able to update the advanced settings of a CCX-enabled course and have the modules and courses populate
- A user on TP should be able to purchase a CCX
