### PR TITLE
Bump django-server-status to 0.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,5 +16,5 @@ requests==2.8.1
 redis==2.10.5
 fake-factory==0.5.3
 factory_boy==2.6.0
-django-server-status==0.2
+django-server-status==0.3
 requests-oauthlib==0.6.0


### PR DESCRIPTION
#### What are the relevant tickets?

https://github.com/mitodl/django-server-status/issues/17
#### What's this PR do?

This will allow for more reliable availability checks from NewRelic: https://github.com/mitodl/django-server-status/pull/19
#### How should this be manually tested?

Just check the output of the `/status` URL exposed by the django-server-status app. If it contains the `status_all` property, it works.

Note: This can only be reviewed once 0.3 is merged and the new package is pushed to pypi.
